### PR TITLE
Fix Issue#34

### DIFF
--- a/src/mkdocs_gallery/gen_gallery.py
+++ b/src/mkdocs_gallery/gen_gallery.py
@@ -717,7 +717,7 @@ def write_junit_xml(all_info: AllInformation, all_results: List[GalleryScriptRes
     output = ''
     for result in all_results:
         t = result.exec_time
-        fname = result.script.src_py_file_rel_project.as_posix()
+        fname = result.script.src_py_file_rel_project
         if not any(fname in x for x in (gallery_conf['passing_examples'],
                                         failing_unexpectedly,
                                         failing_as_expected,

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -518,7 +518,7 @@ def handle_exception(exc_info, script: GalleryScript):
         traceback.format_list(stack) +
         traceback.format_exception_only(etype, exc))
 
-    src_file = script.src_py_file.as_posix()
+    src_file = script.src_py_file
     expected = src_file in _expected_failing_examples(
         gallery_conf=script.gallery_conf, mkdocs_conf=script.gallery.all_info.mkdocs_conf
     )
@@ -767,7 +767,7 @@ def execute_code_block(compiler, block, script: GalleryScript):
 
     cwd = os.getcwd()
     # Redirect output to stdout
-    src_file = script.src_py_file.as_posix()
+    src_file = script.src_py_file
     logging_tee = _check_reset_logging_tee(src_file)
     assert isinstance(logging_tee, _LoggingTee)  # noqa
 
@@ -974,6 +974,12 @@ def generate_file_md(script: GalleryScript, seen_backrefs=None) -> GalleryScript
                 script.gallery_conf['stale_examples'].append(script.dwnld_py_file.as_posix())
 
         if skip_and_return:
+            # If expected to fail, let's assume it did when executed previously
+            if script.src_py_file in script.gallery_conf['expected_failing_examples']:
+                script.gallery_conf['failing_examples'][script.src_py_file] = (
+                    "Due to MD5 check, script has not been actually executed - "
+                    "Assumed it failed as expected during previous execution."
+                )
             # Return with 0 exec time and mem usage, and the existing thumbnail
             thumb_source_path = script.get_thumbnail_source(file_conf)
             thumb_file = create_thumb_from_image(script, thumb_source_path)

--- a/src/mkdocs_gallery/plugin.py
+++ b/src/mkdocs_gallery/plugin.py
@@ -74,22 +74,34 @@ class MySubConfig(co.SubConfig):
         return self
 
 
+class Dir(co.Dir):
+    """mkdocs.config.config_options.Dir replacement: returns a pathlib object instead of a string"""
+    def run_validation(self, value):
+        return Path(co.Dir.run_validation(self, value))
+
+
+class File(co.File):
+    """mkdocs.config.config_options.File replacement: returns a pathlib object instead of a string"""
+    def run_validation(self, value):
+        return Path(co.File.run_validation(self, value))
+
+
 class GalleryPlugin(BasePlugin):
     #     # Mandatory to display plotly graph within the site
     #     import plotly.io as pio
     #     pio.renderers.default = "sphinx_gallery"
 
     config_scheme = (
-        ('conf_script', co.File(exists=True)),
+        ('conf_script', File(exists=True)),
         ('filename_pattern', co.Type(str)),
         ('ignore_pattern', co.Type(str)),
-        ('examples_dirs', ConfigList(co.Dir(exists=True))),
+        ('examples_dirs', ConfigList(Dir(exists=True))),
         # 'reset_argv': DefaultResetArgv(),
         ('subsection_order', co.Choice(choices=(None, "ExplicitOrder"))),
         ('within_subsection_order', co.Choice(choices=("FileNameSortKey", "NumberOfCodeLinesSortKey"))),
 
-        ('gallery_dirs', ConfigList(co.Dir(exists=False))),
-        ('backreferences_dir', co.Dir(exists=False)),
+        ('gallery_dirs', ConfigList(Dir(exists=False))),
+        ('backreferences_dir', Dir(exists=False)),
         ('doc_module', ConfigList(co.Type(str))),
         # 'reference_url': {},  TODO how to link code to external functions?
         ('capture_repr', ConfigList(co.Type(str))),
@@ -103,14 +115,14 @@ class GalleryPlugin(BasePlugin):
         # 'passing_examples': [],
         # 'stale_examples': [],
         ('run_stale_examples', co.Type(bool)),
-        ('expected_failing_examples', ConfigList(co.File(exists=True))),
+        ('expected_failing_examples', ConfigList(File(exists=True))),
         ('thumbnail_size', ConfigList(co.Type(int), single_elt_allowed=False)),
         ('min_reported_time', co.Type(int)),
         ('binder', MySubConfig(
             # Required keys
             ('org', co.Type(str, required=True)),
             ('repo', co.Type(str, required=True)),
-            ('dependencies', ConfigList(co.File(exists=True), required=True)),
+            ('dependencies', ConfigList(File(exists=True), required=True)),
             # Optional keys
             ('branch', co.Type(str, required=True, default="gh-pages")),
             ('binderhub_url', co.URL(required=True, default="https://mybinder.org")),
@@ -134,7 +146,7 @@ class GalleryPlugin(BasePlugin):
         # 'css': _KNOWN_CSS,
         ('matplotlib_animations', co.Type(bool)),
         ('image_srcset', ConfigList(co.Type(str))),
-        ('default_thumb_file', co.File(exists=True)),
+        ('default_thumb_file', File(exists=True)),
         ('line_numbers', co.Type(bool)),
     )
 


### PR DESCRIPTION
Since filepaths are sometimes compared to filepaths stored in the mkdocs/mkdocs-gallery config dict, I had to go back to the source and override `Dir` and `File` classes from `mkdocs.config.config_options` so that they return pathlib objects (2ff91aba3cf8e89de4ebb3ca5c6c3bcab89cbd38).

Then fixing the not-failing-although-expected-to-fail bug (#34) was just a matter of adding the `src_py_file` path to the `gallery_conf['failing_examples']` dict...
... and removing the minimum (but necessary) number of `as_posix()` calls so that the tests and build pass.

Let's check that and see if the CI builds are successful.